### PR TITLE
ricty diminished fontのurlを修正しました

### DIFF
--- a/fonts-ricty-diminished/fonts-ricty-diminished.nuspec
+++ b/fonts-ricty-diminished/fonts-ricty-diminished.nuspec
@@ -37,7 +37,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <title>Ricty Diminished</title>
     <authors>Raph Levien,itouhiro,M+ FONTS PROJECT,Yasunori Yusa</authors>
     <!-- projectUrl is required for the community feed -->
-    <projectUrl>http://www.rs.tus.ac.jp/yyusa/ricty_diminished.html</projectUrl>
+    <projectUrl>http://www.yusa.lab.uec.ac.jp/~yusa/ricty_diminished.html</projectUrl>
     <!--<iconUrl>http://cdn.rawgit.com/__REPLACE_YOUR_REPO__/master/icons/fonts-ricty-diminished.png</iconUrl>-->
     <!-- <copyright>Year Software Vendor</copyright> -->
     <!-- If there is a license Url available, it is is required for the community feed -->

--- a/fonts-ricty-diminished/tools/chocolateyinstall.ps1
+++ b/fonts-ricty-diminished/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'fonts-ricty-diminished'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'http://www.rs.tus.ac.jp/yyusa/ricty_diminished/ricty_diminished-4.1.1.tar.gz'
+$url = 'http://www.yusa.lab.uec.ac.jp/~yusa/ricty_diminished/ricty_diminished-4.1.1.tar.gz'
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir

--- a/fonts-ricty-diminished/update.ps1
+++ b/fonts-ricty-diminished/update.ps1
@@ -4,7 +4,7 @@ function global:au_GetLatest {
      $download_page = Invoke-WebRequest -Uri $releases
      $regex   = '.tar.gz$'
      $verregex= [regex]'ricty_diminished/ricty_diminished-(.*?)\.tar.gz'
-     $url     = "http://www.rs.tus.ac.jp/yyusa/" + ($download_page.links | ? href -match $regex | select -First 1 -expand href)
+     $url     = "http://www.yusa.lab.uec.ac.jp/~yusa/" + ($download_page.links | ? href -match $regex | select -First 1 -expand href)
      $version = $verregex.Match( $url ).Groups[1]
      return @{ 
         Version = $version;


### PR DESCRIPTION
ricty diminished fontのホームページとダウンロードurlが変更になっていたため、修正しました。
[Homebrewへのプルリク](https://github.com/Homebrew/homebrew-cask-fonts/pull/1927/files)を参考にしています。